### PR TITLE
[f] - enable incomplete payments

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -34,7 +34,7 @@ module Koudoku::Subscription
             prepare_for_upgrade if upgrading?
 
             # update the package level with stripe.
-            customer.update_subscription(:plan => self.plan.stripe_id, :prorate => Koudoku.prorate)
+            customer.update_subscription(:plan => self.plan.stripe_id, :prorate => Koudoku.prorate, enable_incomplete_payments: Koudoku.enable_incomplete_payments)
 
             finalize_downgrade! if downgrading?
             finalize_upgrade! if upgrading?
@@ -87,7 +87,7 @@ module Koudoku::Subscription
               customer = Stripe::Customer.create(customer_attributes)
 
               finalize_new_customer!(customer.id, plan.price)
-              customer.update_subscription(:plan => self.plan.stripe_id, :prorate => Koudoku.prorate)
+              customer.update_subscription(:plan => self.plan.stripe_id, :prorate => Koudoku.prorate, enable_incomplete_payments: Koudoku.enable_incomplete_payments)
 
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message

--- a/lib/generators/koudoku/templates/config/initializers/koudoku.rb
+++ b/lib/generators/koudoku/templates/config/initializers/koudoku.rb
@@ -5,6 +5,7 @@ Koudoku.setup do |config|
 
   Stripe.api_version = '2017-08-15' # Making sure the API version used is compatible.
   # config.prorate = false # Default is true, set to false to disable prorating subscriptions
+  # config.enable_incomplete_payments = false # Default is true, set to false to disable imcomplete subscriptions
   # config.free_trial_length = 30
 
   # Specify layout you want to use for the subscription pages, default is application

--- a/lib/koudoku.rb
+++ b/lib/koudoku.rb
@@ -27,6 +27,8 @@ module Koudoku
   mattr_accessor :prorate
   @@prorate = true
 
+  mattr_accessor :enable_incomplete_payments
+  @@enable_incomplete_payments = false
 
   @@layout = nil
 


### PR DESCRIPTION
### 3d secure
For 3d secure. we need to enable incomplete payments.
set enable_incomplete_payments to `true`.
[https://stripe.com/docs/billing/subscriptions/payment](url)

